### PR TITLE
Django 5 fixes

### DIFF
--- a/catchpy/consumer/jwt_middleware.py
+++ b/catchpy/consumer/jwt_middleware.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 import iso8601
 import jwt
 import logging
-import pytz
 
 from django.conf import settings
 

--- a/catchpy/consumer/models.py
+++ b/catchpy/consumer/models.py
@@ -1,24 +1,13 @@
 import logging
-from datetime import datetime
-from datetime import timedelta
-import pytz
+from datetime import datetime, timedelta
 from random import randint
 from uuid import uuid4
-
 from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.auth import get_user_model
-
-from django.db.models import CASCADE, PROTECT
-from django.db.models import BooleanField
-from django.db.models import CharField
-from django.db.models import DateTimeField
-from django.db.models import ForeignKey
-from django.db.models import ManyToManyField
-from django.db.models import Model
-from django.db.models import OneToOneField
-from django.db.models import TextField
+from django.db.models import CASCADE, CharField, DateTimeField, ForeignKey, Model, OneToOneField
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from zoneinfo import ZoneInfo
 
 
 User = get_user_model()
@@ -48,7 +37,7 @@ def create_or_update_user_profile(sender, instance, created, **kwargs):
 
 
 def expire_in_weeks(ttl=24):
-    return datetime.now(pytz.utc) + timedelta(weeks=ttl)
+    return datetime.now(ZoneInfo('UTC')) + timedelta(weeks=ttl)
 
 
 def generate_id():
@@ -70,7 +59,7 @@ class Consumer(Model):
 
     def has_expired(self, now=None):
         if now is None:
-            now = datetime.now(pytz.utc)
+            now = datetime.now(ZoneInfo('UTC'))
         return self.expire_on < now
 
     def __repr__(self):

--- a/catchpy/consumer/models.py
+++ b/catchpy/consumer/models.py
@@ -7,7 +7,10 @@ from django.contrib.auth import get_user_model
 from django.db.models import CASCADE, CharField, DateTimeField, ForeignKey, Model, OneToOneField
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from zoneinfo import ZoneInfo
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 
 User = get_user_model()

--- a/catchpy/consumer/models.py
+++ b/catchpy/consumer/models.py
@@ -56,7 +56,6 @@ class Consumer(Model):
         null=True,
         on_delete=CASCADE)
 
-
     def has_expired(self, now=None):
         if now is None:
             now = datetime.now(ZoneInfo('UTC'))
@@ -69,12 +68,17 @@ class Consumer(Model):
         return self.__repr__()
 
 
-
 @receiver(post_save, sender=CatchpyProfile)
 def create_or_update_profile_consumer(sender, instance, created, **kwargs):
     if created:
-        Consumer.objects.create(prime_profile=instance)
-    instance.prime_consumer.save()
-
-
+        consumer = Consumer.objects.create(parent_profile=instance)
+        instance.prime_consumer = consumer
+        instance.save()
+    else:
+        if not hasattr(instance, 'prime_consumer') or instance.prime_consumer is None:
+            consumer = Consumer.objects.create(parent_profile=instance)
+            instance.prime_consumer = consumer
+            instance.save()
+        else:
+            instance.prime_consumer.save()
 

--- a/catchpy/consumer/tests/test_middleware.py
+++ b/catchpy/consumer/tests/test_middleware.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import pytest
-import pytz
 from django.http import HttpResponse
 from django.test import RequestFactory
 
@@ -181,7 +181,7 @@ def test_middleware_tampered_token():
 
 @pytest.mark.django_db
 def test_middleware_token_expired():
-    date_in_past = datetime.now(pytz.utc) - timedelta(hours=3)
+    date_in_past = datetime.now(ZoneInfo('UTC')) - timedelta(hours=3)
     c = Consumer._default_manager.create()
     token_enc = encode_catchjwt(
         apikey=c.consumer,
@@ -211,7 +211,7 @@ def test_middleware_token_expired():
 
 @pytest.mark.django_db
 def test_middleware_issued_in_future():
-    date_in_future = datetime.now(pytz.utc) + timedelta(hours=3)
+    date_in_future = datetime.now(ZoneInfo('UTC')) + timedelta(hours=3)
     c = Consumer._default_manager.create()
     token_enc = encode_catchjwt(
         apikey=c.consumer,

--- a/catchpy/requirements/base.txt
+++ b/catchpy/requirements/base.txt
@@ -6,7 +6,6 @@ PyJWT>=2.8.0
 PyLD>=2.0.4=3
 python-dateutil>=2.8.2
 python-dotenv>=1.0.0
-pytz>=2023.3
 requests>=2.31.0
 django-log-request-id>=2.1.0
 django-cors-headers>=4.2.0

--- a/catchpy/requirements/base.txt
+++ b/catchpy/requirements/base.txt
@@ -9,3 +9,4 @@ python-dotenv>=1.0.0
 requests>=2.31.0
 django-log-request-id>=2.1.0
 django-cors-headers>=4.2.0
+backports.zoneinfo;python_version<"3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,10 @@ dependencies = [
     "PyLD>=2.0.3, <3.0.0",
     "python-dateutil>=2.8.2",
     "python-dotenv>=1.0.0",
-    "pytz>=2023.3",
     "requests>=2.31.0",
     "django-log-request-id>=2.1.0",
     "django-cors-headers>=4.2.0",
+    "backports.zoneinfo;python_version<'3.9'",
 ]
 
 [tool.hatch.version]

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -16,11 +16,11 @@ RUN for PYTHON_VERSION in 3.8.19 3.9.19 3.10.14 3.11.9 3.12.3; do \
   ; done
 
 # Add to PATH, in order of lowest precedence to highest.
-ENV PATH /root/.pyenv/versions/3.8.17/bin:${PATH}
-ENV PATH /root/.pyenv/versions/3.9.17/bin:${PATH}
-ENV PATH /root/.pyenv/versions/3.10.12/bin:${PATH}
-ENV PATH /root/.pyenv/versions/3.12.2/bin:${PATH}
-ENV PATH /root/.pyenv/versions/3.11.4/bin:${PATH}
+ENV PATH /root/.pyenv/versions/3.8.19/bin:${PATH}
+ENV PATH /root/.pyenv/versions/3.9.19/bin:${PATH}
+ENV PATH /root/.pyenv/versions/3.10.14/bin:${PATH}
+ENV PATH /root/.pyenv/versions/3.12.3/bin:${PATH}
+ENV PATH /root/.pyenv/versions/3.11.9/bin:${PATH}
 
 RUN mkdir /code
 WORKDIR /code


### PR DESCRIPTION
- Remove `pytz` (deprecated in Django 5) and use the native `datetime` and `ZoneInfo` instead
- Fix field reference in the `Consumer` models and update error handling for `CatchpyProfile` `postsave` signal