### PR TITLE
Conditionally import ZoneInfo; use GHA matrix strategy

### DIFF
--- a/.github/workflows/ci-pytest.yml
+++ b/.github/workflows/ci-pytest.yml
@@ -11,17 +11,25 @@ env:
 jobs:
     tests:
         runs-on: ubuntu-latest
+        strategy:
+          matrix:
+            python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
         steps:
-          - uses: actions/checkout@v3
+          - uses: actions/checkout@v4
+
           - name: Build Docker images
             run: |
-              docker compose -f docker-compose-test.yml build
+              PYTHON_VERSION=${{ matrix.python-version }} docker compose -f docker-compose-test.yml build
+
           - name: Run Docker Compose containers
             run: |
-              docker compose -f docker-compose-test.yml up -d
+              PYTHON_VERSION=${{ matrix.python-version }} docker compose -f docker-compose-test.yml up -d
+
           - name: Run Pytest unit tests within Compose
             run: |
-              docker compose -f docker-compose-test.yml exec web bash -c "tox"
+              docker compose -f docker-compose-test.yml exec web pytest
+
           - name: Stop Docker Compose containers
             if: always()
             run: docker compose -f docker-compose.yml down

--- a/README.rst
+++ b/README.rst
@@ -162,10 +162,10 @@ tests are located under each Django app:
 Github Actions CI
 ---------------
 Github Actions is configured to run unit tests on every new PR. The tests are configured in
-``.github/workflows/ci-pytest.yml``. The workflow is configured to run tests on Python3.8-3.12 using
-``tox``.
-
----eop
+``.github/workflows/ci-pytest.yml``. The workflow is configured to run tests on Python 3.8-3.12
+(currently supported versions) using `pytest` and a parallelized Github Actions matrix strategy which passes
+the Python version as a build argument to the Dockerfile. `tox` is configured for local developmment
+tests if that is preferred over `act`. 
 
 
 .. _W3C Web Annotation Data Model: https://www.w3.org/TR/annotation-model/

--- a/catchpy/__init__.py
+++ b/catchpy/__init__.py
@@ -1,3 +1,3 @@
 # important to use single quotes in version string
 # for post-commit tagging
-__version__ = '2.9.0'
+__version__ = '2.9.1'

--- a/catchpy/consumer/tests/test_middleware.py
+++ b/catchpy/consumer/tests/test_middleware.py
@@ -1,9 +1,11 @@
 from datetime import datetime, timedelta
-from zoneinfo import ZoneInfo
-
 import pytest
 from django.http import HttpResponse
 from django.test import RequestFactory
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 from ..catchjwt import decode_token, encode_catchjwt, validate_token
 from ..jwt_middleware import (

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -12,6 +12,8 @@ services:
     build: 
       context: .
       dockerfile: test.Dockerfile
+      args:
+        PYTHON_VERSION: ${PYTHON_VERSION}
     image: hx/catchpy:test
     command: ["./wait-for-it.sh", "db:5432", "--", "python", "manage.py", "runserver", "0.0.0.0:8000"]
     volumes:

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,26 +1,12 @@
-FROM python:3.11
+# pass in Python version as build arg to allow for tests to be run on multiple versions of Python
+ARG PYTHON_VERSION=3.11
+FROM python:${PYTHON_VERSION}
+ENV PYTHONUNBUFFERED 1
 ENV PYTHONUNBUFFERED 1
 
-RUN apt-get update
-
 # Include fortune library for quote generation for text annotations
-RUN apt-get install fortune-mod -y
+RUN apt-get update && apt-get install -y fortune-mod
 ENV PATH "$PATH:/usr/games"
-
-# Install all other versions of Python we want to test with tox
-RUN git clone https://github.com/pyenv/pyenv /root/.pyenv
-RUN for PYTHON_VERSION in 3.8.19 3.9.19 3.10.14 3.11.9 3.12.3; do \
-  set -ex \
-    && /root/.pyenv/bin/pyenv install ${PYTHON_VERSION} \
-    && /root/.pyenv/versions/${PYTHON_VERSION}/bin/python -m pip install --upgrade pip \
-  ; done
-
-# Add to PATH, in order of lowest precedence to highest.
-ENV PATH /root/.pyenv/versions/3.8.19/bin:${PATH}
-ENV PATH /root/.pyenv/versions/3.9.19/bin:${PATH}
-ENV PATH /root/.pyenv/versions/3.10.14/bin:${PATH}
-ENV PATH /root/.pyenv/versions/3.12.3/bin:${PATH}
-ENV PATH /root/.pyenv/versions/3.11.9/bin:${PATH}
 
 RUN mkdir /code
 WORKDIR /code


### PR DESCRIPTION
## Change Summary

This PR changes our test strategy from using [`tox`](https://tox.wiki/en/4.15.0/) to using Github Action's matrix strategy for tests. A matrix strategy lets you use variables in a single job definition to automatically create multiple job runs that are based combinations of variables - here, just multiple versions of Python. We pass the `python_version` from GHA as a build argument to Docker Compose and `Dockerfile.test` to control the Python Docker base image. This creates multiple containers, but they run in parallel and should build faster, run faster, and be easier to debug than managing multiple versions of Python and PATH in one image. `tox` is still available for local testing if preferred over `act`, but you might need to pass `PYTHON_VERSION` to the `docker compose build` step.

This allows Catchpy to work with Django 5, which allows us to upgrade MCH to v5.

## Related issue number

Jira DAR-434

## Checklist

- [x] PR title is descriptive
- [x] Added/Modified tests for the changes (or explain why not relevant)
- [x] Manually tested the changes and investigated potential regressions
- [x] Documented changes (where applicable)
