### PR TITLE
Django package

### DIFF
--- a/.github/workflows/ci-pytest.yml
+++ b/.github/workflows/ci-pytest.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
           matrix:
-            python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+            python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
         steps:
           - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.12
 ENV PYTHONUNBUFFERED 1
 
 RUN apt-get update

--- a/README.rst
+++ b/README.rst
@@ -272,7 +272,8 @@ Finally, be sure to run migrations.
 Build and Package
 -----------------
 
+**Build** Wheel
 - install `hatch <https://hatch.pypa.io/latest/install/>`_
 - set version in ``catchpy/__init__.py``
-- package (create Python wheel) ``hatch build``
-- publish to PYPI with ``hatch publish``
+- package (create Python wheel) ``hatch build``. This will create ``.tar.gz`` and ``.whl`` files in the ``./dist`` directory. Catchpy is currently a pure Python package, so the ``.whl`` file is platform independent and can be build on any platform.
+- create a new release on Github and upload the ``.tar.gz`` and ``.whl`` files. Tag the release with the version number. The ``.whl`` file can be targeted as a dependency in other projects.

--- a/catchpy/__init__.py
+++ b/catchpy/__init__.py
@@ -1,3 +1,3 @@
 # important to use single quotes in version string
 # for post-commit tagging
-__version__ = '2.9.2'
+__version__ = '3.0.0'

--- a/catchpy/anno/tests/test_urls.py
+++ b/catchpy/anno/tests/test_urls.py
@@ -39,7 +39,7 @@ def test_urls():
             'url': reverse('create_or_search'),
             'view_func': 'catchpy.anno.views.create_or_search'},
         {
-            'url': '/catchpy/annos/123-456-789',
+            'url': '/annos/123-456-789',
             'view_func': 'catchpy.anno.views.crud_api'},
     ]
 

--- a/catchpy/consumer/models.py
+++ b/catchpy/consumer/models.py
@@ -7,10 +7,7 @@ from django.contrib.auth import get_user_model
 from django.db.models import CASCADE, CharField, DateTimeField, ForeignKey, Model, OneToOneField
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-try:
-    from zoneinfo import ZoneInfo
-except ImportError:
-    from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 
 User = get_user_model()

--- a/catchpy/consumer/tests/test_middleware.py
+++ b/catchpy/consumer/tests/test_middleware.py
@@ -2,10 +2,7 @@ from datetime import datetime, timedelta
 import pytest
 from django.http import HttpResponse
 from django.test import RequestFactory
-try:
-    from zoneinfo import ZoneInfo
-except ImportError:
-    from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 from ..catchjwt import decode_token, encode_catchjwt, validate_token
 from ..jwt_middleware import (

--- a/catchpy/requirements/base.txt
+++ b/catchpy/requirements/base.txt
@@ -9,4 +9,3 @@ python-dotenv>=1.0.0
 requests>=2.31.0
 django-log-request-id>=2.1.0
 django-cors-headers>=4.2.0
-backports.zoneinfo;python_version<"3.9"

--- a/catchpy/requirements/base.txt
+++ b/catchpy/requirements/base.txt
@@ -3,7 +3,7 @@ iso8601>=2.0.0
 jsonschema>=4.18.4
 psycopg>=3.1.8
 PyJWT>=2.8.0
-PyLD>=2.0.4=3
+PyLD>=2.0.4
 python-dateutil>=2.8.2
 python-dotenv>=1.0.0
 requests>=2.31.0

--- a/catchpy/urls.py
+++ b/catchpy/urls.py
@@ -29,5 +29,5 @@ urls = [
 # urlpatterns = urls + [path('admin/', admin.site.urls)]x
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('catchpy/', include(urls)),
+    path('', include(urls)),
 ]

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,7 +1,6 @@
-version: '3'
 services:
   db:
-    image: postgres:15
+    image: postgres:16
     ports:
       - "8001:5432"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   db:
     image: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres
+    image: postgres:16
     ports:
       - "8001:5432"
     environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ dependencies = [
     "requests>=2.31.0",
     "django-log-request-id>=2.1.0",
     "django-cors-headers>=4.2.0",
-    "backports.zoneinfo;python_version<'3.9'",
 ]
 
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "Annotation storage backend"
 readme = "README.rst"
 authors = [
     { name = "nmaekawa", email = "nmaekawa@g.harvard.edu" },
+    { name = "arthurian", email = "abarrett@fas.harvard.edu" },
     { name = "coledcrawford", email = "cole_crawford@fas.harvard.edu" },
     { name = "d-flood", email = "david_flood@fas.harvard.edu" },
 ]
@@ -19,20 +20,22 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
     "Intended Audience :: Developers",
     "Natural Language :: English",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "Django>=4.2",
     "iso8601>=2.0.0",
     "jsonschema>=4.18.4",
     "PyJWT>=2.8.0",
-    "PyLD>=2.0.3, <3.0.0",
+    "PyLD>=2.0.4, <3.0.0",
     "python-dateutil>=2.8.2",
     "python-dotenv>=1.0.0",
     "requests>=2.31.0",

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,5 +1,5 @@
 # pass in Python version as build arg to allow for tests to be run on multiple versions of Python
-ARG PYTHON_VERSION=3.11
+ARG PYTHON_VERSION=3.12
 FROM python:${PYTHON_VERSION}
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONUNBUFFERED 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 env_list =
-    py38
     py39
     py310
     py311
     py312
+    py313
 
 [testenv]
 deps =


### PR DESCRIPTION
This PR removes the URL namespace so that this update no longer includes breaking changes for upstream users.

Additional items mentioned by @ColeDCrawford below:

- [x] Test matrix should cover Python 3.9 - 3.13
- [x] Pin PSQL to v15 or v16 in docker-compose config files
- [x] Remove version key in docker-compose config files
- [x] Switch to python3.12 in Dockerfile
- ~~[ ] See whether we can pin Django to 5.x series?~~
- [x] Bump version to 3.0.0 and document any process for building Github releases
